### PR TITLE
Improve Date to be allow to use for Date From and Date To

### DIFF
--- a/src/DateFilter.php
+++ b/src/DateFilter.php
@@ -4,6 +4,117 @@ namespace R64\Filters;
 
 abstract class DateFilter extends CustomFilter
 {
+	/**
+     * Is the Date Filter is use for Date From.
+     *
+     * @var bool
+     */
+    public $is_date_from = false;
+
+    /**
+     * Is the Date Filter is use for Date To.
+     *
+     * @var bool
+     */
+    public $is_date_to = false;
+
+    /**
+     * Default options of Date.
+     * 
+     * @var array
+     */
+    public $options = [
+		'dateFormat' => 'Y-m-d',
+	];
+
+    /**
+     * Determine if the Date filter use for Date From.
+     * 
+     * @return boolean 
+     */
+    public function isDateFrom()
+    {
+        return $this->is_date_from;
+    }
+
+     /**
+     * Determine if the Date filter use for Date To.
+     * 
+     * @return boolean 
+     */
+    public function isDateTo()
+    {
+        return $this->is_date_to;
+    }
+
+    /**
+     * Get Date Operand.
+     *
+     * @return string
+     */
+    public function getOperand()
+    {
+        if ($this->isDateFrom()) {
+            return '>=';
+        }
+
+        if ($this->isDateTo()) {
+            return '<=';
+        }
+
+        return '=';
+    }
+
+    /**
+     * Get Date Field From $date_field property.
+     *
+     * @return string
+     */
+    public function getDateField()
+    {
+        return $this->date_field;
+    }
+
+    /**
+     * Get Date Options.
+     * 
+     * @return array
+     */
+    public function getOptions()
+    {
+    	return $this->options;
+    }
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param \Illuminate\Http\Request              $request
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed                                 $value
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        return $query->where(
+            $this->getDateField(),
+            $this->getOperand(),
+            $value
+        );
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        return $this->getOptions();
+    }
+
     /**
      * The name of the Vue component to be used for this filter
      *


### PR DESCRIPTION
This PR enabled developers to have a nice Date From and Date To Feature - Date Range.

To enable developers to use the feature simply create new Filter, then extend the `R64\Filters\DateFilter` class, then define as following:

### The Setup

```php
namespace App\Nova\Filters;

class DateFrom extends Date
{
    public $date_field = 'created_at';

    public $is_date_from = true;
}
```

```php
namespace App\Nova\Filters;

class DateTo extends Date
{
    public $date_field = 'created_at';

    public $is_date_to = true;
}
```

### The Usage

```php
...
    public function filters(Request $request)
    {
        return [
            new Filters\DateFrom(),
            new Filters\DateTo(),
        ];
    }
...
```

### Others

Other than this feature, developers may define `public $options` to define Date config